### PR TITLE
unify spelling of SHA-1

### DIFF
--- a/draft-ietf-tls-md5-sha1-deprecate-00.xml
+++ b/draft-ietf-tls-md5-sha1-deprecate-00.xml
@@ -141,7 +141,7 @@
     proved SHA-1 collision attacks were practical.
      This document updates <xref
      target="RFC5246">RFC&nbsp;5246</xref> and <xref target="RFC7525">RFC7525 </xref> 
-     in such as way that MD5 and SHA1 MUST NOT
+     in such as way that MD5 and SHA-1 MUST NOT
      be used for digital signatures.  However, this document does not deprecate SHA-1 in HMAC for record protection.
 </t>
 


### PR DESCRIPTION
SHA-1 is spelled everywhere as "SHA-1", it's the only instance
of "SHA1"

change it so that it is consistent